### PR TITLE
Tweak event handling for captured elements

### DIFF
--- a/inky/core/pointer/internal.lua
+++ b/inky/core/pointer/internal.lua
@@ -152,17 +152,39 @@ do
 		---@type Inky.Element[]
 		local elements = {}
 
-		for i = 1, self._overlappingElements:count() do
-			---@type Inky.Element
-			local element = self._overlappingElements:getByIndex(i)
-			elements[i] = element
-		end
+		local numCaptured = self._capturedElements:count()
 
-		for i = 1, self._capturedElements:count() do
+		for i = 1, numCaptured do
 			---@type Inky.Element
 			local element = self._capturedElements:getByIndex(i)
 
-			if (not self._overlappingElements:has(element)) then
+			elements[#elements + 1] = element
+
+		end
+
+		local sceneInternal = assert(self._scene):__getInternal()
+
+		for i = 1, self._overlappingElements:count() do
+			---@type Inky.Element
+			local element = self._overlappingElements:getByIndex(i)
+
+			local addToElements = true
+
+			-- If the number of captured elements is more than zero,
+			-- element will only be added if it is a descendant of any captured element.
+			if (numCaptured > 0) then
+				addToElements = false
+				if (not self._capturedElements:has(element)) then
+					for j = 1, numCaptured do
+						addToElements = sceneInternal:isElementAChildOf(element, self._capturedElements:getByIndex(j))
+						if (addToElements) then
+							break
+						end
+					end
+				end
+			end
+
+			if (addToElements) then
 				elements[#elements + 1] = element
 			end
 		end

--- a/inky/core/pointer/internal.lua
+++ b/inky/core/pointer/internal.lua
@@ -159,7 +159,6 @@ do
 			local element = self._capturedElements:getByIndex(i)
 
 			elements[#elements + 1] = element
-
 		end
 
 		local sceneInternal = assert(self._scene):__getInternal()

--- a/inky/core/scene/internal.lua
+++ b/inky/core/scene/internal.lua
@@ -238,6 +238,30 @@ function Internal:getElementParent(element)
 	return self._parents[element]
 end
 
+---Recursively check if element is the child of parentElement
+---@param element Inky.Element
+---@param possibleParent Inky.Element
+---@return boolean
+---@nodiscard
+function Internal:isElementAChildOf(element, possibleParent)
+	local actualParent = self:getElementParent(element)
+
+	-- Bounded to avoid potential infinite loops from cyclical references
+	for _ = 1, 64 do
+		if (not actualParent) then
+			return false
+		end
+
+		if (actualParent == possibleParent) then
+			return true
+		end
+
+		actualParent = self:getElementParent(actualParent)
+	end
+
+	return false
+end
+
 ---@param element Inky.Element
 ---@return self
 ---@private

--- a/inky/core/scene/internal.lua
+++ b/inky/core/scene/internal.lua
@@ -238,7 +238,7 @@ function Internal:getElementParent(element)
 	return self._parents[element]
 end
 
----Recursively check if element is the child of parentElement
+---Check if element is a descendant of possibleParent
 ---@param element Inky.Element
 ---@param possibleParent Inky.Element
 ---@return boolean


### PR DESCRIPTION
This change makes it so only overlapped elements that are also children of the captured elements will be sent events (if there's no captured elements, it works as normal). Before, any overlapped element would be added to the list, resulting in certain higher-depth elements taking priority over a captured element.

This adds one new function to the internal of `Scene`:
`function Internal:isElementAChildOf(element, possibleParent)`.

I tested this on a project I'm currently working on and everything seems to work as expected (assuming this behavior is what one would expect when capturing an element)